### PR TITLE
feat: add yearly gains chart and break-even time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,8 @@
 - Bootstrap project with Vite and React
 - Added simulator component
 - Added Tailwind CSS setup
+
+## Unreleased
+
+- Added chart of nominal and real gains over time
+- Show break-even time in results tables


### PR DESCRIPTION
## Summary
- add chart showing nominal and real gains over years
- include break-even time in result tables
- document new chart and table info in changelog

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a97860b93483329b7e68776c48e2e5