### PR TITLE
feat: animate backgrounds by step

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -136,6 +136,15 @@ export default function App(){
   const [step, setStep] = useState(0);
   const [loading, setLoading] = useState(false);
 
+  const backgrounds = [
+    'from-indigo-50 via-purple-50 to-slate-50',
+    'from-indigo-100 via-purple-100 to-slate-100',
+    'from-indigo-200 via-purple-200 to-slate-200',
+    'from-indigo-300 via-purple-300 to-slate-300',
+    'from-indigo-400 via-purple-400 to-slate-400',
+    'from-indigo-500 via-purple-500 to-slate-500',
+  ];
+
   // Base
   const [price, setPrice] = useState(150000);
   const [downPct, setDownPct] = useState(0.15);
@@ -195,7 +204,7 @@ export default function App(){
   const diffAmtB = sB.gainReal - sB.principal * targetPct;
 
   return (
-    <div className="min-h-screen bg-gradient-to-b from-indigo-50 to-slate-100 text-slate-800">
+    <div className={`min-h-screen bg-gradient-to-br ${backgrounds[step]} animate-gradient text-slate-800`}>
       <div className="max-w-5xl mx-auto p-6">
         <header className="flex items-center gap-3 mb-6">
           <Calculator className="w-7 h-7 text-indigo-600" />
@@ -205,7 +214,6 @@ export default function App(){
         <AnimatePresence mode="wait">
           {loading && (
             <motion.div key="loading" initial={{opacity:0}} animate={{opacity:1}} exit={{opacity:0}} className="bg-white p-6 rounded-2xl shadow flex flex-col items-center gap-4">
-              <img src="/images/computer.jpg" alt="Loading" className="w-full h-40 object-cover rounded-xl" />
               <p className="text-lg font-medium">Elaborazione complessa in corso...</p>
               <div className="w-full h-2 bg-slate-200 rounded-full overflow-hidden">
                 <motion.div className="h-full bg-indigo-600" initial={{width:'0%'}} animate={{width:'100%'}} transition={{duration:2}} />
@@ -215,7 +223,6 @@ export default function App(){
 
           {!loading && step===0 && (
             <motion.div key="landing" initial={{opacity:0,x:50}} animate={{opacity:1,x:0}} exit={{opacity:0,x:-50}} transition={{duration:0.4}} className="bg-white p-6 rounded-2xl shadow space-y-6 text-center">
-              <img src="/images/modern-house.jpg" alt="Casa moderna" className="w-full h-48 object-cover rounded-xl" />
               <h2 className="text-2xl font-bold">Scopri se conviene mutuo o cash</h2>
               <p className="text-slate-600">Simula scenari diversi e trova la scelta migliore.</p>
               <button onClick={()=>setStep(1)} className="px-6 py-3 bg-indigo-600 text-white rounded-xl inline-flex items-center gap-2">Prova ora <ArrowRight className="w-4 h-4"/></button>
@@ -224,7 +231,6 @@ export default function App(){
 
           {!loading && step===1 && (
             <motion.div key="s1" initial={{opacity:0,x:50}} animate={{opacity:1,x:0}} exit={{opacity:0,x:-50}} transition={{duration:0.4}} className="bg-white p-6 rounded-2xl shadow space-y-6">
-              <img src="/images/house.jpg" alt="Casa" className="w-full h-40 object-cover rounded-xl" />
               <h2 className="text-lg font-medium">Step 1 – Parametri base</h2>
               <Grid>
                 <Field label="Prezzo casa" value={price} onChange={setPrice} min={50000} max={2000000} step={1000} prefix="€" />
@@ -240,7 +246,6 @@ export default function App(){
 
           {!loading && step===2 && (
             <motion.div key="s2" initial={{opacity:0,x:50}} animate={{opacity:1,x:0}} exit={{opacity:0,x:-50}} transition={{duration:0.4}} className="bg-white p-6 rounded-2xl shadow space-y-6">
-              <img src="/images/finance.jpg" alt="Finanza" className="w-full h-40 object-cover rounded-xl" />
               <h2 className="text-lg font-medium">Step 2 – Tassi & inflazione</h2>
               <Grid>
                 <Field label="TAN mutuo (%)" value={tan*100} onChange={(v)=>setTan(v/100)} min={0} max={10} step={0.1} suffix="%" />
@@ -257,7 +262,6 @@ export default function App(){
 
           {!loading && step===3 && (
             <motion.div key="s3" initial={{opacity:0,x:50}} animate={{opacity:1,x:0}} exit={{opacity:0,x:-50}} transition={{duration:0.4}} className="bg-white p-6 rounded-2xl shadow space-y-6">
-              <img src="/images/savings.jpg" alt="Risparmio" className="w-full h-40 object-cover rounded-xl" />
               <h2 className="text-lg font-medium">Step 3 – Contributi extra</h2>
               <div className="space-y-3">
                 <Field label="Contributo mensile (€)" value={monthlyExtra} onChange={setMonthlyExtra} min={0} max={50000} step={50} prefix="€" />
@@ -272,7 +276,6 @@ export default function App(){
 
           {!loading && step===4 && (
             <motion.div key="s4" initial={{opacity:0,x:50}} animate={{opacity:1,x:0}} exit={{opacity:0,x:-50}} transition={{duration:0.4}} className="bg-white p-6 rounded-2xl shadow space-y-6">
-              <img src="/images/salary.jpg" alt="Stipendio" className="w-full h-40 object-cover rounded-xl" />
               <h2 className="text-lg font-medium">Step 4 – Stipendio & soglia guadagno</h2>
               <div className="space-y-3">
                 <Field label="Stipendio netto annuale" value={salary} onChange={setSalary} min={0} max={1000000} step={1000} prefix="€" />
@@ -287,7 +290,6 @@ export default function App(){
 
           {!loading && step===5 && (
             <motion.div key="s5" initial={{opacity:0,x:50}} animate={{opacity:1,x:0}} exit={{opacity:0,x:-50}} transition={{duration:0.4}} className="space-y-6">
-              <img src="/images/chart.jpg" alt="Risultati" className="w-full h-40 object-cover rounded-xl" />
               <Card>
                 <h2 className="text-lg font-medium mb-2">Risultati</h2>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-3">

--- a/src/index.css
+++ b/src/index.css
@@ -5,3 +5,20 @@
 body {
   margin: 0;
 }
+
+@keyframes gradient-move {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
+}
+
+.animate-gradient {
+  background-size: 200% 200%;
+  animation: gradient-move 8s ease infinite;
+}


### PR DESCRIPTION
## Summary
- remove step images and apply animated gradient backgrounds that intensify across the wizard
- add reusable gradient animation utilities

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a9c5c4af1083328e976788225a4c47