### PR TITLE
Show white wizard title only on results page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -206,10 +206,12 @@ export default function App(){
   return (
     <div className={`min-h-screen bg-gradient-to-br ${backgrounds[step]} animate-gradient text-slate-800`}>
       <div className="max-w-5xl mx-auto p-6">
-        <header className="flex items-center gap-3 mb-6">
-          <Calculator className="w-7 h-7 text-orange-600" />
-          <h1 className="text-2xl md:text-3xl font-semibold">The wise investor's wizard 🚀</h1>
-        </header>
+        {step === 5 && (
+          <header className="flex items-center gap-3 mb-6">
+            <Calculator className="w-7 h-7 text-orange-600" />
+            <h1 className="text-2xl md:text-3xl font-semibold text-white">The wise investor's wizard 🚀</h1>
+          </header>
+        )}
 
         <AnimatePresence mode="wait">
           {loading && (


### PR DESCRIPTION
## Summary
- Render "The wise investor's wizard" header only on final step
- Make title text white to match results background

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9c9f21c4483328ce3397c13bc2d7a