### PR TITLE
Show title on all steps with adaptive color

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -203,15 +203,15 @@ export default function App(){
   const diffPctB = sB.gainReal / sB.principal - targetPct;
   const diffAmtB = sB.gainReal - sB.principal * targetPct;
 
+  const titleColor = step >= 4 ? "text-white" : "text-slate-800";
+
   return (
     <div className={`min-h-screen bg-gradient-to-br ${backgrounds[step]} animate-gradient text-slate-800`}>
       <div className="max-w-5xl mx-auto p-6">
-        {step === 5 && (
-          <header className="flex items-center gap-3 mb-6">
-            <Calculator className="w-7 h-7 text-orange-600" />
-            <h1 className="text-2xl md:text-3xl font-semibold text-white">The wise investor's wizard 🚀</h1>
-          </header>
-        )}
+        <header className="flex items-center gap-3 mb-6">
+          <Calculator className="w-7 h-7 text-orange-600" />
+          <h1 className={`text-2xl md:text-3xl font-semibold ${titleColor}`}>The wise investor's wizard 🚀</h1>
+        </header>
 
         <AnimatePresence mode="wait">
           {loading && (


### PR DESCRIPTION
## Summary
- Display the main wizard title on every step instead of only the final results page.
- Adjust title color based on the background gradient to maintain readability.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9caad367c8332abedd5aad8d53360