### PR TITLE
Improve wizard navigation and landing

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -4,6 +4,7 @@
 
 body {
   @apply font-sans;
+  font-family: 'Inter', sans-serif;
   margin: 0;
 }
 


### PR DESCRIPTION
## Summary
- Add cancel/continue popup when no investment is selected
- Refresh landing screen with start button and detailed examples
- Add restart option on every step and apply Inter font globally

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68acc6abfbb08332bed1ca6f1479d513