### PR TITLE
Add hero section and guide routing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "lucide-react": "^0.541.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-router-dom": "^6.30.1",
         "recharts": "^3.1.2"
       },
       "devDependencies": {
@@ -852,6 +853,15 @@
         "react-redux": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -2723,6 +2733,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lucide-react": "^0.541.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-router-dom": "^6.30.1",
     "recharts": "^3.1.2"
   },
   "devDependencies": {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,8 @@ import { motion, AnimatePresence } from "framer-motion";
 import { LineChart, Line, XAxis, YAxis, Tooltip, Legend, ResponsiveContainer, ReferenceLine } from "recharts";
 import { Calculator, TrendingUp, ArrowRight, Home, PiggyBank, Wallet, WalletCards } from "lucide-react";
 
+import { Link } from "react-router-dom";
+
 // -------------------- Utils --------------------
 const fmt = (n) => n.toLocaleString("it-IT", { style: "currency", currency: "EUR", maximumFractionDigits: 0 });
 const fmt2 = (n) => n.toLocaleString("it-IT", { style: "currency", currency: "EUR", maximumFractionDigits: 2 });
@@ -198,6 +200,15 @@ function ConfigCard({ title, description, details = [], icon: Icon, onSteps, onR
     </div>
   );
 }
+  function GuideCard({ to, title, description }) {
+    return (
+      <Link to={to} className="block p-5 bg-white rounded-2xl shadow border border-slate-200 hover:shadow-md transition">
+        <h3 className="text-md font-medium mb-1">{title}</h3>
+        <p className="text-sm text-slate-600">{description}</p>
+      </Link>
+    );
+  }
+
 
 function YearSelector({ label, value, onChange, description }){
   const presets = [10, 20, 30];
@@ -610,85 +621,21 @@ export default function App(){
           )}
 
           {!loading && step===0 && (
-            <motion.div key="landing" initial={{opacity:0,x:50}} animate={{opacity:1,x:0}} exit={{opacity:0,x:-50}} transition={{duration:0.4}} className="space-y-6">
-              <div className="text-center">
-                <button onClick={()=>{resetAll(); setStep(1);}} className="px-6 py-3 bg-orange-600 text-white rounded-xl text-lg shadow">Inizia</button>
-              </div>
-              <h2 className="text-xl font-semibold text-center">Oppure scegli un esempio</h2>
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <ConfigCard
-                  icon={Home}
-                  title="Vuoi solo il mutuo?"
-                  description="Scopri l'andamento del debito senza investimenti. Es: mutuo €150k, anticipo 15% con durate 15-25 anni."
-                  details={["Mutuo €150k", "Anticipo 15%", "Nessun investimento"]}
-                  onSteps={() => {
-                    applyConfig(1);
-                    setStep(1);
-                  }}
-                  onResults={() => {
-                    applyConfig(1);
-                    setLoading(true);
-                    setTimeout(() => {
-                      setLoading(false);
-                      setStep(4);
-                    }, 2000);
-                  }}
-                />
-                <ConfigCard
-                  icon={PiggyBank}
-                  title="Hai risparmi mensili da investire?"
-                  description="Valuta quando chiudere il mutuo investendo 300€ al mese. Durate 10-20-30 anni."
-                  details={["Mutuo €150k", "Anticipo 15%", "Risparmi 300€/mese"]}
-                  onSteps={() => {
-                    applyConfig(2);
-                    setStep(1);
-                  }}
-                  onResults={() => {
-                    applyConfig(2);
-                    setLoading(true);
-                    setTimeout(() => {
-                      setLoading(false);
-                      setStep(4);
-                    }, 2000);
-                  }}
-                />
-                <ConfigCard
-                  icon={Wallet}
-                  title="Investi la tua disponibilità?"
-                  description="Simula la chiusura anticipata investendo 300€ al mese con rendimenti attesi del 5%. Durate 15-25-35 anni."
-                  details={["Mutuo €150k", "Anticipo 15%", "Investi 300€/mese", "Rendimento atteso 5%"]}
-                  onSteps={() => {
-                    applyConfig(3);
-                    setStep(1);
-                  }}
-                  onResults={() => {
-                    applyConfig(3);
-                    setLoading(true);
-                    setTimeout(() => {
-                      setLoading(false);
-                      setStep(4);
-                    }, 2000);
-                  }}
-                />
-                <ConfigCard
-                  icon={WalletCards}
-                  title="Hai già capitale investito?"
-                  description="Decidi se accendere un mutuo tenendo investiti €50k. Confronta durate 20 e 40 anni."
-                  details={["Mutuo €150k", "Anticipo 15%", "Capitale investito €50k", "Rendimento atteso 5%"]}
-                  onSteps={() => {
-                    applyConfig(4);
-                    setStep(1);
-                  }}
-                  onResults={() => {
-                    applyConfig(4);
-                    setLoading(true);
-                    setTimeout(() => {
-                      setLoading(false);
-                      setStep(4);
-                    }, 2000);
-                  }}
-                />
-              </div>
+            <motion.div key="landing" initial={{opacity:0,x:50}} animate={{opacity:1,x:0}} exit={{opacity:0,x:-50}} transition={{duration:0.4}} className="space-y-12">
+              <section className="text-center py-20">
+                <h1 className="text-4xl font-bold mb-4">Buy or Loan</h1>
+                <p className="text-lg mb-6">Confronta mutuo e investimento per prendere la decisione migliore.</p>
+                <a href="#guide" className="px-6 py-3 bg-orange-600 text-white rounded-xl shadow">Scopri di più</a>
+              </section>
+              <section id="guide" className="space-y-6">
+                <h2 className="text-2xl font-semibold text-center">Guide</h2>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <GuideCard to="/mutuo" title="Mutuo" description="Concetti base del mutuo." />
+                  <GuideCard to="/mutuo-risparmi-chiusura" title="Mutuo e risparmi" description="Usa i risparmi per chiudere il mutuo." />
+                  <GuideCard to="/mutuo-investimento" title="Mutuo e investimento" description="Combina mutuo e investimento." />
+                  <GuideCard to="/investimento" title="Investimento" description="Strategie di investimento." />
+                </div>
+              </section>
             </motion.div>
           )}
 

--- a/src/guides/Investimento.jsx
+++ b/src/guides/Investimento.jsx
@@ -1,0 +1,9 @@
+import React from "react";
+export default function Investimento() {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold mb-4">Guida all'Investimento</h1>
+      <p>Consigli e strategie per investire in modo efficace.</p>
+    </div>
+  );
+}

--- a/src/guides/Mutuo.jsx
+++ b/src/guides/Mutuo.jsx
@@ -1,0 +1,9 @@
+import React from "react";
+export default function Mutuo() {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold mb-4">Guida Mutuo</h1>
+      <p>Informazioni generali sul mutuo.</p>
+    </div>
+  );
+}

--- a/src/guides/MutuoInvestimento.jsx
+++ b/src/guides/MutuoInvestimento.jsx
@@ -1,0 +1,9 @@
+import React from "react";
+export default function MutuoInvestimento() {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold mb-4">Mutuo e Investimento</h1>
+      <p>Come combinare mutuo e investimento per massimizzare i benefici.</p>
+    </div>
+  );
+}

--- a/src/guides/MutuoRisparmiChiusura.jsx
+++ b/src/guides/MutuoRisparmiChiusura.jsx
@@ -1,0 +1,9 @@
+import React from "react";
+export default function MutuoRisparmiChiusura() {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold mb-4">Mutuo e Risparmi per la Chiusura</h1>
+      <p>Strategie per chiudere il mutuo utilizzando i risparmi.</p>
+    </div>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,23 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
+import { createBrowserRouter, RouterProvider } from 'react-router-dom'
 import App from './App.jsx'
+import Mutuo from './guides/Mutuo.jsx'
+import MutuoRisparmiChiusura from './guides/MutuoRisparmiChiusura.jsx'
+import MutuoInvestimento from './guides/MutuoInvestimento.jsx'
+import Investimento from './guides/Investimento.jsx'
 import './index.css'
+
+const router = createBrowserRouter([
+  { path: '/', element: <App /> },
+  { path: '/mutuo', element: <Mutuo /> },
+  { path: '/mutuo-risparmi-chiusura', element: <MutuoRisparmiChiusura /> },
+  { path: '/mutuo-investimento', element: <MutuoInvestimento /> },
+  { path: '/investimento', element: <Investimento /> },
+])
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
-  </React.StrictMode>
+    <RouterProvider router={router} />
+  </React.StrictMode>,
 )


### PR DESCRIPTION
## Summary
- Add landing hero with description and "Scopri di più" button
- Introduce guide cards linking to new guide pages
- Set up React Router to handle guide routes

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68accf652b2483329526f48621373d41