### PR TITLE
Add mortgage and investment guide pages

### DIFF
--- a/src/InvestimentoGuide.jsx
+++ b/src/InvestimentoGuide.jsx
@@ -1,0 +1,39 @@
+import React from "react";
+
+export default function InvestimentoGuide() {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold mb-4">Guida all'Investimento</h1>
+      <p className="mb-4">
+        Concetti base per iniziare a investire e costruire un portafoglio diversificato.
+      </p>
+      <h2 className="text-xl font-semibold mb-2">Esempio pratico</h2>
+      <p className="mb-4">
+        Investendo 300€ al mese in un ETF globale con rendimento medio del 6% puoi accumulare circa 20.000€ in 5 anni.
+      </p>
+      <h2 className="text-xl font-semibold mb-2">Link utili</h2>
+      <ul className="list-disc pl-5 space-y-1">
+        <li>
+          <a
+            href="https://www.mef.gov.it/it/Focus/Investire-con-consapevolezza/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-600 underline"
+          >
+            Investire con consapevolezza - MEF
+          </a>
+        </li>
+        <li>
+          <a
+            href="https://www.morningstar.it/it/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-600 underline"
+          >
+            Analisi su fondi ed ETF
+          </a>
+        </li>
+      </ul>
+    </div>
+  );
+}

--- a/src/MutuoGuide.jsx
+++ b/src/MutuoGuide.jsx
@@ -1,0 +1,39 @@
+import React from "react";
+
+export default function MutuoGuide() {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold mb-4">Guida al Mutuo</h1>
+      <p className="mb-4">
+        Un'introduzione ai mutui ipotecari, alle rate e alle principali voci di costo.
+      </p>
+      <h2 className="text-xl font-semibold mb-2">Esempio pratico</h2>
+      <p className="mb-4">
+        Per un mutuo di 200.000€ al 3% su 20 anni la rata mensile è circa 1.109€.
+      </p>
+      <h2 className="text-xl font-semibold mb-2">Link utili</h2>
+      <ul className="list-disc pl-5 space-y-1">
+        <li>
+          <a
+            href="https://www.bancaditalia.it/compiti/vigilanza/linee-guida/guida-mutui/index.html"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-600 underline"
+          >
+            Guida ai mutui della Banca d'Italia
+          </a>
+        </li>
+        <li>
+          <a
+            href="https://www.ilsole24ore.com/art/mutui-2024-come-scegliere-taeg-e-indici-riferimento-AEkkafLB"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-600 underline"
+          >
+            Articolo di approfondimento sui tassi
+          </a>
+        </li>
+      </ul>
+    </div>
+  );
+}

--- a/src/MutuoInvestimentoGuide.jsx
+++ b/src/MutuoInvestimentoGuide.jsx
@@ -1,0 +1,39 @@
+import React from "react";
+
+export default function MutuoInvestimentoGuide() {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold mb-4">Mutuo e Investimento</h1>
+      <p className="mb-4">
+        Valutare se conviene investire il capitale disponibile o utilizzarlo per ridurre l'importo del mutuo.
+      </p>
+      <h2 className="text-xl font-semibold mb-2">Esempio pratico</h2>
+      <p className="mb-4">
+        Investendo 50.000€ al 5% annuo invece di versarli come anticipo si possono ottenere oltre 65.000€ dopo 5 anni.
+      </p>
+      <h2 className="text-xl font-semibold mb-2">Link utili</h2>
+      <ul className="list-disc pl-5 space-y-1">
+        <li>
+          <a
+            href="https://www.money.it/mutuo-o-investimento-quale-conviene"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-600 underline"
+          >
+            Mutuo o investimento, cosa conviene?
+          </a>
+        </li>
+        <li>
+          <a
+            href="https://www.soldionline.it/guide/risparmio/investire-medio-lungo-termine"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-600 underline"
+          >
+            Guida all'investimento a medio-lungo termine
+          </a>
+        </li>
+      </ul>
+    </div>
+  );
+}

--- a/src/MutuoRisparmiChiusuraGuide.jsx
+++ b/src/MutuoRisparmiChiusuraGuide.jsx
@@ -1,0 +1,39 @@
+import React from "react";
+
+export default function MutuoRisparmiChiusuraGuide() {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold mb-4">Mutuo, Risparmi e Chiusura Anticipata</h1>
+      <p className="mb-4">
+        Questa pagina spiega come accumulare risparmi durante il mutuo e valutarne la chiusura anticipata.
+      </p>
+      <h2 className="text-xl font-semibold mb-2">Esempio pratico</h2>
+      <p className="mb-4">
+        Con un risparmio extra di 200€ al mese puoi ridurre la durata del mutuo ventennale di diversi anni.
+      </p>
+      <h2 className="text-xl font-semibold mb-2">Link utili</h2>
+      <ul className="list-disc pl-5 space-y-1">
+        <li>
+          <a
+            href="https://www.altroconsumo.it/soldi/mutuo/consigli/mutuo-estinzione-anticipata"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-600 underline"
+          >
+            Consigli sull'estinzione anticipata del mutuo
+          </a>
+        </li>
+        <li>
+          <a
+            href="https://www.ilmutuoblog.it/2019/10/come-estinguere-mutuo-anticipatamente.html"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-600 underline"
+          >
+            Come estinguere un mutuo in anticipo
+          </a>
+        </li>
+      </ul>
+    </div>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,18 +2,18 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { createBrowserRouter, RouterProvider } from 'react-router-dom'
 import App from './App.jsx'
-import Mutuo from './guides/Mutuo.jsx'
-import MutuoRisparmiChiusura from './guides/MutuoRisparmiChiusura.jsx'
-import MutuoInvestimento from './guides/MutuoInvestimento.jsx'
-import Investimento from './guides/Investimento.jsx'
+import MutuoGuide from './MutuoGuide.jsx'
+import MutuoRisparmiChiusuraGuide from './MutuoRisparmiChiusuraGuide.jsx'
+import MutuoInvestimentoGuide from './MutuoInvestimentoGuide.jsx'
+import InvestimentoGuide from './InvestimentoGuide.jsx'
 import './index.css'
 
 const router = createBrowserRouter([
   { path: '/', element: <App /> },
-  { path: '/mutuo', element: <Mutuo /> },
-  { path: '/mutuo-risparmi-chiusura', element: <MutuoRisparmiChiusura /> },
-  { path: '/mutuo-investimento', element: <MutuoInvestimento /> },
-  { path: '/investimento', element: <Investimento /> },
+  { path: '/mutuo', element: <MutuoGuide /> },
+  { path: '/mutuo-risparmi-chiusura', element: <MutuoRisparmiChiusuraGuide /> },
+  { path: '/mutuo-investimento', element: <MutuoInvestimentoGuide /> },
+  { path: '/investimento', element: <InvestimentoGuide /> },
 ])
 
 ReactDOM.createRoot(document.getElementById('root')).render(


### PR DESCRIPTION
## Summary
- add dedicated guide pages for mortgage, mortgage payoff, mortgage vs investment, and investing
- wire new guides into router

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acd0b02a6083329f8843853681922f