### PR TITLE
fix: use relative asset links on home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,15 +5,15 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#ffffff" />
     <title>Buy or Loan Simulator</title>
-    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
-    <link rel="apple-touch-icon" sizes="192x192" href="/favicon-192.png" />
-    <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
+    <link rel="apple-touch-icon" sizes="192x192" href="./favicon-192.png" />
+    <link rel="manifest" href="./manifest.webmanifest" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
+    <script type="module" src="./src/main.jsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- use relative paths for favicon, manifest and script on the root page so assets load when deployed under a subdirectory

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68bb104d71008332a95441124a9c8922